### PR TITLE
Truncate long links

### DIFF
--- a/imports/client/components/ChatMessage.tsx
+++ b/imports/client/components/ChatMessage.tsx
@@ -5,6 +5,7 @@ import styled from "styled-components";
 import type { ChatMessageContentType } from "../../lib/models/ChatMessages";
 import nodeIsMention from "../../lib/nodeIsMention";
 import { MentionSpan } from "./FancyEditor";
+import { shortCalendarTimeFormat } from "../../lib/calendarTimeFormat";
 
 // This file implements standalone rendering for the MessageElement format
 // defined by FancyEditor, for use in the chat pane.
@@ -62,14 +63,28 @@ const MarkdownToken = ({ token }: { token: marked.Token }) => {
     }
     return <PreWrapParagraph>{children}</PreWrapParagraph>;
   } else if (token.type === "link") {
-    const children = token.tokens.map((t, i) => (
-      <MarkdownToken key={i} token={t} />
-    ));
+    // const children = token.tokens.map((t, i) => (
+    //   <MarkdownToken key={i} token={t} />
+    // ));
+
+    // Truncate the link href
+    let displayedHref = token.href;
+    const pathStart = token.href.indexOf('/', token.href.indexOf('//') + 2); // Find the start of the path
+    if (pathStart !== -1 && token.href.length - pathStart > 50) {
+      displayedHref = token.href.slice(0, pathStart + 10) + '... [truncated]';
+    }
+
     return (
-      <a target="_blank" rel="noopener noreferrer" href={token.href}>
-        {children}
+      <a target="_blank" rel="noopener noreferrer" title={`{children}`}href={token.href}>
+        {displayedHref} {/* Display the truncated href */}
       </a>
     );
+
+    // return (
+    //   <a target="_blank" rel="noopener noreferrer" href={token.href}>
+    //     {children}
+    //   </a>
+    // );
   } else if (token.type === "blockquote") {
     const children = token.tokens.map((t, i) => (
       <MarkdownToken key={i} token={t} />
@@ -112,10 +127,12 @@ const ChatMessage = ({
   message,
   displayNames,
   selfUserId,
+  timestamp
 }: {
   message: ChatMessageContentType;
   displayNames: Map<string, string>;
   selfUserId: string;
+  timestamp?: Date;
 }) => {
   const children = message.children.map((child, i) => {
     if (nodeIsMention(child)) {
@@ -133,7 +150,7 @@ const ChatMessage = ({
     }
   });
 
-  return <div>{children}</div>;
+  return <div>{timestamp ? (<span>{shortCalendarTimeFormat(timestamp)}:<br/></span>) : null}{children}</div>;
 };
 
 export default ChatMessage;


### PR DESCRIPTION
If a link's path is more than 50 characters long, we truncate the anchor text to the first 20 characters, and then append "... [truncated]".

This should affect only long links like those containing data or search parameters, and make chat more readable.