### PR TITLE
This allows for messages to be pinned.

### DIFF
--- a/imports/client/components/PuzzleActivity.tsx
+++ b/imports/client/components/PuzzleActivity.tsx
@@ -1,5 +1,5 @@
 import { Meteor } from "meteor/meteor";
-import { useTracker } from "meteor/react-meteor-data";
+import { useFind, useTracker } from "meteor/react-meteor-data";
 import { faCommentDots } from "@fortawesome/free-solid-svg-icons/faCommentDots";
 import { faDoorOpen } from "@fortawesome/free-solid-svg-icons/faDoorOpen";
 import { faFilePen } from "@fortawesome/free-solid-svg-icons/faFilePen";
@@ -55,6 +55,7 @@ const PuzzleActivityItem = styled.span`
     `,
   )}
 `;
+
 
 const PuzzleOpenTime = styled(PuzzleActivityItem)`
   min-width: 4.66rem;

--- a/imports/server/methods/sendChatMessage.ts
+++ b/imports/server/methods/sendChatMessage.ts
@@ -36,7 +36,7 @@ defineMethod(sendChatMessage, {
     if (('children' in contentObj) &&
     (contentObj.children.length > 0) &&
     ('text' in contentObj.children[0]) &&
-    (contentObj.children[0].text.match(/^\s*\/pin\s+/i))) {
+    (contentObj.children[0].text.match(/^\s*\/pin\s+\S+/i))) {
       isPinned = true;
       contentObj.children[0].text = contentObj.children[0].text.replace(/^\s*\/pin\s+/, '');
     }


### PR DESCRIPTION
This change does a few things:

- `sendChatMessage` now looks for a message that starts with /pin and sets a 'pinned' property to 'true' if it is

- The left pane now renders messages that are pinned with a different highlight colour, and also prepends 📌 to the sender name

- The left pane now additionally always displays the first 12 or so lines of the pinned message at the top, with any thing else visible by scrolling

- The main puzzle page now displays puzzles that have notes, along with the time that has elapsed since the last pinned message was sent. On hover, this also displays the a truncated portion of the pinned message