### PR TITLE
Hide more guess queue functionality when queue is disabled.

### DIFF
--- a/imports/client/components/HuntNav.tsx
+++ b/imports/client/components/HuntNav.tsx
@@ -167,10 +167,12 @@ const HuntNav = () => {
 
         <StyledPuzzleListLinkAnchor
           to={`/hunts/${huntId}/guesses`}
-          title="Guess queue"
+          title={hunt.hasGuessQueue ? "Guess queue" : "Answer log"}
         >
           <MenuIcon icon={faReceipt} />
-          <StyledPuzzleListLinkLabel>Guesses</StyledPuzzleListLinkLabel>
+          <StyledPuzzleListLinkLabel>
+            {hunt.hasGuessQueue ? "Guesses" : "Answers"}
+          </StyledPuzzleListLinkLabel>
         </StyledPuzzleListLinkAnchor>
 
         <StyledPuzzleListLinkAnchor

--- a/imports/client/components/NotificationCenter.tsx
+++ b/imports/client/components/NotificationCenter.tsx
@@ -959,6 +959,7 @@ const NotificationCenter = () => {
     const hunt = hunts.get(g.hunt);
     const puzzle = puzzles.get(g.puzzle);
     if (!hunt || !puzzle) return;
+    if (!hunt.hasGuessQueue) return;
     messages.push(
       <GuessMessage
         key={g._id}


### PR DESCRIPTION
- Disable guess notifications
- Hide extraneous columns from the guess queue page
- Rename "Guess queue" to "Answer log" and "Guesses" to "Answers"

Fixes #2168