### PR TITLE
Exclude Drive Activity from the server's Google account.

### DIFF
--- a/imports/lib/models/Settings.ts
+++ b/imports/lib/models/Settings.ts
@@ -10,6 +10,7 @@ const SettingDiscriminatedUnion = z.discriminatedUnion("name", [
     value: z.object({
       refreshToken: nonEmptyString,
       email: nonEmptyString,
+      id: nonEmptyString.optional(),
     }),
   }),
   z.object({

--- a/imports/server/gdriveActivityFetcher.ts
+++ b/imports/server/gdriveActivityFetcher.ts
@@ -68,6 +68,7 @@ async function fetchDriveActivity() {
   }
 
   const root = await Settings.findOneAsync({ name: "gdrive.root" });
+  const credential = await Settings.findOneAsync({ name: "gdrive.credential" });
 
   // Don't fetch history that's older than what we'd display
   const previousTimestamp = Math.max(
@@ -121,9 +122,13 @@ async function fetchDriveActivity() {
         const actorIds = [
           ...activity.actors.reduce<Set<string>>((acc, actor) => {
             if (actor.user?.knownUser?.personName?.startsWith("people/")) {
-              acc.add(
-                actor.user.knownUser.personName.substring("people/".length),
+              const actorId = actor.user.knownUser.personName.substring(
+                "people/".length,
               );
+              // Exclude edits made by the server drive user, since these aren't actual user edits.
+              if (!credential?.value?.id || credential?.value?.id !== actorId) {
+                acc.add(actorId);
+              }
             }
 
             return acc;

--- a/imports/server/methods/configureGdriveCreds.ts
+++ b/imports/server/methods/configureGdriveCreds.ts
@@ -25,11 +25,11 @@ defineMethod(configureGdriveCreds, {
     }
 
     const credential = Google.retrieveCredential(key, secret);
-    const { refreshToken, email } = credential.serviceData;
+    const { refreshToken, email, id } = credential.serviceData;
     Logger.info("Updating Gdrive creds", { email });
     await Settings.upsertAsync(
       { name: "gdrive.credential" },
-      { $set: { value: { refreshToken, email } } },
+      { $set: { value: { refreshToken, email, id } } },
     );
   },
 });


### PR DESCRIPTION
It appears that the drive API counts various actions taken by the server account in the process of creating a new document for a puzzle as edits (in that the edit field is populated). This is confusing as it looks like there is drive activity in every new puzzle when it is first created, even if nobody has opened it or edited the document.

We can filter out events associated with the ID of the server account to prevent this confusion. Given that this account is recommended to not be one used for actual hunting, this seems like a reasonable approach.

We were not previously storing the ID when logging into a server account. We store it for future sign-ins, but for simplicity, do not bother with backfill. This means that until the server admin signs in again, they will continue to see activity under the server admin.

Also note that regardless of which account you're logged into JR with, Sheets activity will be associated with the default Google account in your browser session.