### PR TITLE
update puzzle page

### DIFF
--- a/imports/client/components/PuzzlePage.tsx
+++ b/imports/client/components/PuzzlePage.tsx
@@ -131,6 +131,7 @@ const FilteredChatFields = [
   "content",
   "sender",
   "timestamp",
+  "pinTs",
 ] as const;
 type FilteredChatMessageType = Pick<
   ChatMessageType,
@@ -565,7 +566,7 @@ const ChatHistory = React.forwardRef(
             !!lastMessage &&
             lastMessage.sender === msg.sender &&
             lastMessage.timestamp.getTime() + 60000 > msg.timestamp.getTime() &&
-            !msg.pinned;
+            msg.pinTs !== null;
           const isHighlighted = messageDingsUser(msg, selfUser);
           return (
             <ChatHistoryMessage
@@ -573,7 +574,7 @@ const ChatHistory = React.forwardRef(
               message={msg}
               displayNames={displayNames}
               isSystemMessage={msg.sender === undefined}
-              isPinned={msg.pinned === true}
+              isPinned={msg.pinTs !== null}
               isHighlighted={isHighlighted}
               suppressSender={suppressSender}
               selfUserId={selfUser._id}
@@ -718,7 +719,7 @@ const PinnedMessage = React.forwardRef(
               message={msg}
               displayNames={displayNames}
               isSystemMessage={msg.sender === undefined}
-              isPinned={msg.pinned === true}
+              isPinned={msg.pinTs !== null}
               isHighlighted={false}
               suppressSender={false}
               selfUserId={selfUser._id}


### PR DESCRIPTION
This gets pinned messages closer to what I want them to be.

Pins are now indicated by the presence of a non-null `pinTs` on a chat message, which the UI surfaces in a number of places.

In future, existing messages will be able to be pinned, and pinned messages will be able to be unpinned (I haven't exactly decided on the mechanism for this yet)