### PR TITLE
try to guess and autopopulate the puzzle title based on the puzzle url

### DIFF
--- a/imports/client/components/PuzzleModalForm.tsx
+++ b/imports/client/components/PuzzleModalForm.tsx
@@ -98,10 +98,12 @@ const PuzzleModalForm = React.forwardRef(
     );
     const [errorMessage, setErrorMessage] = useState<string>("");
     const [titleDirty, setTitleDirty] = useState<boolean>(false);
+    const [lastAutoPopulatedTitle, setLastAutoPopulatedTitle] = useState<string>("");
     const [urlDirty, setUrlDirty] = useState<boolean>(false);
     const [tagsDirty, setTagsDirty] = useState<boolean>(false);
     const [expectedAnswerCountDirty, setExpectedAnswerCountDirty] =
       useState<boolean>(false);
+
 
     const formRef = useRef<ModalFormHandle>(null);
 
@@ -277,6 +279,32 @@ const PuzzleModalForm = React.forwardRef(
           </Col>
         </FormGroup>
       ) : null;
+
+      useEffect(() => {
+        // This tries to guess the puzzle title based on the URL entered
+        // To keep things simple, we only populate the title if the title
+        // is currently blank,
+        try {
+          const urlObject = new URL(url);
+          const pathname = urlObject.pathname.replace(/^\/|\/$/g, '');
+          if (!pathname) return;
+          const pathParts = pathname.split("/");
+          const lastPart = pathParts[pathParts.length - 1];
+          const decodedLastPart = decodeURI(lastPart);
+          const formattedTitle = decodedLastPart
+            .replace(/-/g, " ")
+            .replace(/\w\S*/g, (txt) => txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase());
+
+            if (title === lastAutoPopulatedTitle || title === '') {
+              setTitle(formattedTitle);
+              setTitleDirty(false);
+          }
+          setLastAutoPopulatedTitle(formattedTitle);
+        } catch (error) {
+          console.error("Invalid URL:", error);
+        }
+      }, [url]);
+
 
     return (
       <Suspense


### PR DESCRIPTION
This tries to guess and autopopulate a puzzle's title, given its URL.

This will work in cases where the URL's last path part is the puzzle, and not where it isn't.

It will only guess/update the guessed title if the title is currently blank, or if the title's current value matches the most recently populated title