### PR TITLE
Feature/embedded puzzle page

### DIFF
--- a/imports/client/components/DocumentDisplay.tsx
+++ b/imports/client/components/DocumentDisplay.tsx
@@ -9,6 +9,7 @@ import type { DocumentType } from "../../lib/models/Documents";
 interface DocumentDisplayProps {
   document: DocumentType;
   displayMode: "link" | "embed";
+  isShown: boolean;
 }
 
 const StyledDeepLink = styled.a`
@@ -17,7 +18,7 @@ const StyledDeepLink = styled.a`
   white-space: nowrap;
 `;
 
-const StyledIframe = styled.iframe`
+const StyledIframe = styled.iframe<{ $isShown: boolean }>`
   /* Workaround for unusual sizing behavior of iframes in iOS Safari:
    * Width and height need to be specified in absolute values then adjusted by min and max */
   width: 0;
@@ -31,6 +32,7 @@ const StyledIframe = styled.iframe`
   border: 0;
   padding-bottom: env(safe-area-inset-bottom, 0);
   background-color: #f1f3f4;
+  z-index: ${({ $isShown }) => ($isShown ? 1 : -1)};
 `;
 
 export const DocumentMessage = styled.span`
@@ -43,6 +45,7 @@ export const DocumentMessage = styled.span`
 const GoogleDocumentDisplay = ({
   document,
   displayMode,
+  isShown,
 }: DocumentDisplayProps) => {
   let url: string;
   let title: string;
@@ -76,7 +79,14 @@ const GoogleDocumentDisplay = ({
       );
     case "embed":
       /* To workaround iOS Safari iframe behavior, scrolling should be "no" */
-      return <StyledIframe title="document" scrolling="no" src={url} />;
+      return (
+        <StyledIframe
+          title="document"
+          scrolling="no"
+          src={url}
+          $isShown={isShown}
+        />
+      );
     default:
       return (
         <DocumentMessage>Unknown displayMode {displayMode}</DocumentMessage>
@@ -84,11 +94,19 @@ const GoogleDocumentDisplay = ({
   }
 };
 
-const DocumentDisplay = ({ document, displayMode }: DocumentDisplayProps) => {
+const DocumentDisplay = ({
+  document,
+  displayMode,
+  isShown,
+}: DocumentDisplayProps) => {
   switch (document.provider) {
     case "google":
       return (
-        <GoogleDocumentDisplay document={document} displayMode={displayMode} />
+        <GoogleDocumentDisplay
+          document={document}
+          displayMode={displayMode}
+          isShown={isShown}
+        />
       );
     default:
       return (

--- a/imports/client/components/HuntEditPage.tsx
+++ b/imports/client/components/HuntEditPage.tsx
@@ -244,6 +244,9 @@ const HuntEditPage = () => {
   const [isArchived, setIsArchived] = useState<boolean>(
     hunt?.isArchived ?? false,
   );
+  const [allowPuzzleEmbed, setAllowPuzzleEmbed] = useState<boolean>(
+    hunt?.allowPuzzleEmbed ?? true,
+  );
   const [termsOfUse, setTermsOfUse] = useState<string>(hunt?.termsOfUse ?? "");
   const [showTermsOfUsePreview, setShowTermsOfUsePreview] =
     useState<boolean>(false);
@@ -344,6 +347,13 @@ const HuntEditPage = () => {
   const onIsArchivedChanged = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
       setIsArchived(e.currentTarget.checked);
+    },
+    [],
+  );
+
+  const onAllowEmbedChanged = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      setAllowPuzzleEmbed(e.currentTarget.checked);
     },
     [],
   );
@@ -449,6 +459,7 @@ const HuntEditPage = () => {
         firehoseDiscordChannel,
         memberDiscordRole,
         isArchived,
+        allowPuzzleEmbed,
         defaultRoles,
         moreInfo: moreInfo === "" ? undefined : moreInfo,
         archivedHuntUrl: archivedHuntUrl === "" ? undefined : archivedHuntUrl,
@@ -476,6 +487,7 @@ const HuntEditPage = () => {
       firehoseDiscordChannel,
       memberDiscordRole,
       isArchived,
+      allowPuzzleEmbed,
       defaultRoles,
       moreInfo,
       archivedHuntUrl,
@@ -716,6 +728,27 @@ const HuntEditPage = () => {
               <code>{"{{{origin}}}/submit{{{pathname}}}"}</code> would work for
               the 2018 Mystery Hunt. If not specified, the puzzle URL is used as
               the link to the guess submission page.
+            </FormText>
+          </Col>
+        </FormGroup>
+
+        <FormGroup as={Row} className="mb-3">
+          <FormLabel column xs={3} htmlFor="hunt-form-allow-embed">
+            Allow puzzle embedding
+          </FormLabel>
+          <Col xs={9}>
+            <FormCheck
+              id="hunt-form-allow-embed"
+              checked={allowPuzzleEmbed}
+              onChange={onAllowEmbedChanged}
+              disabled={disableForm}
+              type="switch"
+              label={allowPuzzleEmbed ? "Allowed" : "Not allowed"}
+            />
+            <FormText>
+              If enabled, we will allow users to view puzzle pages in Jolly
+              Roger. This should be disabled where site security settings (e.g.
+              CORS) prevent us from iFraming the website.
             </FormText>
           </Col>
         </FormGroup>

--- a/imports/client/components/PuzzlePage.tsx
+++ b/imports/client/components/PuzzlePage.tsx
@@ -1957,6 +1957,10 @@ const PuzzlePageMetadata = ({
     </Button>
   ) : null;
 
+  const canEmbedPuzzle = useTracker(() => {
+    return hunt?.allowPuzzleEmbed ?? false;
+  }, [hunt])
+
   const handleShowButtonClick = () => {
     if (!hasIframeBeenLoaded) {
       setHasIframeBeenLoaded(true);
@@ -1964,9 +1968,16 @@ const PuzzlePageMetadata = ({
     setShowDocument(!showDocument);
   };
 
-  const togglePuzzleInset = puzzle.url && isDesktop ? (
+  const handleShowButtonHover = () => {
+    if (!hasIframeBeenLoaded) {
+      setHasIframeBeenLoaded(true);
+    }
+  }
+
+  const togglePuzzleInset = (puzzle.url && isDesktop && canEmbedPuzzle) || !showDocument ? (
     <Button
     onClick={handleShowButtonClick}
+    onMouseEnter={handleShowButtonHover}
     variant="secondary"
     size="sm"
     title={showDocument ? "View Puzzle" : "Hide Puzzle"}
@@ -2783,6 +2794,13 @@ const PuzzlePage = React.memo(() => {
   const huntId = useParams<"huntId">().huntId!;
   const puzzleId = useParams<"puzzleId">().puzzleId!;
 
+
+  const hunt = useTracker(() => {return Hunts.findOne(huntId)}, [huntId]);
+
+  const showPuzzleDocument = useTracker(() => {
+    return (hunt?.allowPuzzleEmbed ?? false) ? true : showDocument;
+  }, [hunt, showDocument]);
+
   // Add the current user to the collection of people viewing this puzzle.
   const subscribersTopic = `puzzle:${puzzleId}`;
   useSubscribe("subscribers.inc", subscribersTopic, {
@@ -3039,7 +3057,7 @@ const PuzzlePage = React.memo(() => {
             {chat}
             <PuzzleContent>
               {metadata}
-              <PuzzlePageMultiplayerDocument document={doc} isShown={showDocument} showDocument={showDocument}/>
+              <PuzzlePageMultiplayerDocument document={doc} showDocument={showPuzzleDocument}/>
               {
                 activePuzzle.url && hasIframeBeenLoaded ?
                   (

--- a/imports/client/components/PuzzlePage.tsx
+++ b/imports/client/components/PuzzlePage.tsx
@@ -1807,6 +1807,8 @@ const PuzzlePageMetadata = ({
   isDesktop,
   showDocument,
   setShowDocument,
+  hasIframeBeenLoaded,
+  setHasIframeBeenLoaded,
 }: {
   puzzle: PuzzleType;
   bookmarked: boolean;
@@ -1815,6 +1817,8 @@ const PuzzlePageMetadata = ({
   isDesktop: boolean;
   showDocument: boolean;
   setShowDocument: (showDocument: boolean) => void;
+  hasIframeBeenLoaded: boolean;
+  setHasIframeBeenLoaded: (hasIframeBeenLoaded: boolean) => void;
 }) => {
   const huntId = puzzle.hunt;
   const puzzleId = puzzle._id;
@@ -1954,6 +1958,9 @@ const PuzzlePageMetadata = ({
   ) : null;
 
   const handleShowButtonClick = () => {
+    if (!hasIframeBeenLoaded) {
+      setHasIframeBeenLoaded(true);
+    }
     setShowDocument(!showDocument);
   };
 
@@ -2769,6 +2776,7 @@ const PuzzlePage = React.memo(() => {
   const [isDesktop, setIsDesktop] = useState<boolean>(
     window.innerWidth >= MinimumDesktopWidth,
   );
+  const [hasIframeBeenLoaded, setHasIframeBeenLoaded] = useState(false);
   const [replyingTo, setReplyingTo] = useState<string | null>(null);
   const [showDocument, setShowDocument] = useState<boolean>(true);
 
@@ -2944,6 +2952,8 @@ const PuzzlePage = React.memo(() => {
       isDesktop={isDesktop}
       showDocument={showDocument}
       setShowDocument={setShowDocument}
+      hasIframeBeenLoaded={hasIframeBeenLoaded}
+      setHasIframeBeenLoaded={setHasIframeBeenLoaded}
     />
   );
   const chat = (
@@ -3030,7 +3040,12 @@ const PuzzlePage = React.memo(() => {
             <PuzzleContent>
               {metadata}
               <PuzzlePageMultiplayerDocument document={doc} isShown={showDocument} showDocument={showDocument}/>
-              <StyledIframe $isShown={!showDocument} src={activePuzzle.url}/>
+              {
+                activePuzzle.url && hasIframeBeenLoaded ?
+                  (
+                    <StyledIframe $isShown={!showDocument} src={activePuzzle.url}/>
+                  ) : null
+              }
               {debugPane}
             </PuzzleContent>
           </SplitPanePlus>

--- a/imports/lib/models/Hunts.ts
+++ b/imports/lib/models/Hunts.ts
@@ -61,6 +61,8 @@ const EditableHunt = z.object({
   archivedHuntUrl: nonEmptyString.url().optional(),
   // If set, this is a string that defines a regex pattern for the original hunt URL
   originalHuntUrlRegex: nonEmptyString.optional(),
+  // If set, this is a boolean that enables/disables showing puzzle pages in Jolly Roger
+  allowPuzzleEmbed: z.boolean().default(false).optional(),
 });
 export type EditableHuntType = z.infer<typeof EditableHunt>;
 const Hunt = withCommon(EditableHunt);
@@ -84,6 +86,7 @@ export const HuntPattern = {
   firehoseDiscordChannel: Match.Optional(SavedDiscordObjectPattern),
   memberDiscordRole: Match.Optional(SavedDiscordObjectPattern),
   isArchived: Match.Optional(Boolean),
+  allowPuzzleEmbed: Match.Optional(Boolean),
   defaultRoles: [String] as [StringConstructor],
   moreInfo: Match.Optional(String),
   archivedHuntUrl: Match.Optional(String),


### PR DESCRIPTION
This implements embedded puzzle pages.

I think this is mostly as much as I want to do with it . You can check the puzzle page pretty quickly if you need to, and if you need something more (like a windowed version) my personal view is that you can probably just open a new browser window - it's less fragile and complicated for us to maintain, and most of the time, this view of just the puzzle page is enough (you are not often simultaneously accessing the puzzle page and the spreadsheet).

There is a hunt-level setting that defaults to enabled, where you can disable this setting if the Hunt site for some reason does not permit you to iframe pages at all.